### PR TITLE
Refactor image utilities and add storage tests

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,35 +1,9 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-// Define protected routes that require authentication
-const protectedRoutes = [
-  '/dashboard',
-  '/editor',
-  '/images',
-  '/templates',
-  '/designs',
-  '/profile'
-];
-
-// Define public routes that should redirect authenticated users
-const publicRoutes = [
-  '/auth',
-  '/login',
-  '/signup'
-];
-
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   
-  // Check if the current path is a protected route
-  const isProtectedRoute = protectedRoutes.some(route => 
-    pathname.startsWith(route)
-  );
-  
-  // Check if the current path is a public route
-  const isPublicRoute = publicRoutes.some(route => 
-    pathname.startsWith(route)
-  );
 
   // For now, we'll handle authentication checks on the client side
   // since Firebase Auth state is not available in middleware

--- a/src/__tests__/hooks/useUserProfile.test.tsx
+++ b/src/__tests__/hooks/useUserProfile.test.tsx
@@ -74,7 +74,7 @@ describe('useUserProfile', () => {
     await act(async () => {
       try {
         await result.current.updateProfile({ displayName: 'New Name' })
-      } catch (error) {
+      } catch {
         // Expected to throw
       }
     })

--- a/src/__tests__/lib/firestore.test.ts
+++ b/src/__tests__/lib/firestore.test.ts
@@ -6,7 +6,7 @@ import {
   saveDesign,
   incrementUsageStats,
 } from '@/lib/firestore'
-import { doc, getDoc, setDoc, updateDoc, getDocs, query, where, orderBy, Timestamp } from 'firebase/firestore'
+import { doc, getDoc, setDoc, updateDoc, getDocs, query, where, orderBy } from 'firebase/firestore'
 
 // Mock Firebase functions
 jest.mock('firebase/firestore')

--- a/src/__tests__/lib/storage.test.ts
+++ b/src/__tests__/lib/storage.test.ts
@@ -1,0 +1,31 @@
+import { isValidImageFile, isValidFileSize, generateUniqueFilename, SUPPORTED_IMAGE_TYPES, FILE_SIZE_LIMITS } from '@/lib/storage';
+
+describe('storage utility functions', () => {
+  test('isValidImageFile returns true for supported types', () => {
+    SUPPORTED_IMAGE_TYPES.forEach(type => {
+      const file = new File([], 'test.' + type.split('/')[1], { type });
+      expect(isValidImageFile(file)).toBe(true);
+    });
+  });
+
+  test('isValidImageFile returns false for unsupported types', () => {
+    const file = new File([], 'test.txt', { type: 'text/plain' });
+    expect(isValidImageFile(file)).toBe(false);
+  });
+
+  test('isValidFileSize respects limit', () => {
+    const smallFile = new File([new Uint8Array(FILE_SIZE_LIMITS.IMAGE - 1)], 'small.png', { type: 'image/png' });
+    const largeFile = new File([new Uint8Array(FILE_SIZE_LIMITS.IMAGE + 1)], 'large.png', { type: 'image/png' });
+    expect(isValidFileSize(smallFile, FILE_SIZE_LIMITS.IMAGE)).toBe(true);
+    expect(isValidFileSize(largeFile, FILE_SIZE_LIMITS.IMAGE)).toBe(false);
+  });
+
+  test('generateUniqueFilename preserves extension and uniqueness', () => {
+    const name = 'photo.png';
+    const generated1 = generateUniqueFilename(name);
+    const generated2 = generateUniqueFilename(name);
+    expect(generated1).not.toEqual(generated2);
+    expect(generated1.endsWith('.png')).toBe(true);
+    expect(generated2.endsWith('.png')).toBe(true);
+  });
+});

--- a/src/__tests__/services/userProfile.test.ts
+++ b/src/__tests__/services/userProfile.test.ts
@@ -1,5 +1,5 @@
 import { UserProfileService } from '@/services/userProfile'
-import { doc, getDoc, setDoc, updateDoc, Timestamp } from 'firebase/firestore'
+import { doc, getDoc, setDoc, updateDoc } from 'firebase/firestore'
 import { SUBSCRIPTION_PLANS, FREE_TIER_LIMITS } from '@/types/firestore'
 
 // Mock Firebase functions

--- a/src/__tests__/utils/test-utils.tsx
+++ b/src/__tests__/utils/test-utils.tsx
@@ -1,6 +1,5 @@
 import React, { ReactElement } from 'react'
 import { render, RenderOptions } from '@testing-library/react'
-import { AuthProvider } from '@/contexts/AuthContext'
 import { UserProfile } from '@/types'
 
 // Mock AuthContext for testing

--- a/src/components/categories/CategoryManager.tsx
+++ b/src/components/categories/CategoryManager.tsx
@@ -32,7 +32,7 @@ export function CategoryManager({ onCategoryChange }: CategoryManagerProps) {
       await addCustomCategory(newCategoryName);
       setNewCategoryName('');
       onCategoryChange?.();
-    } catch (err) {
+    } catch {
       // Error is handled by the hook
     } finally {
       setIsSubmitting(false);
@@ -48,7 +48,7 @@ export function CategoryManager({ onCategoryChange }: CategoryManagerProps) {
       setIsSubmitting(true);
       await removeCustomCategory(categoryName);
       onCategoryChange?.();
-    } catch (err) {
+    } catch {
       // Error is handled by the hook
     } finally {
       setIsSubmitting(false);
@@ -69,7 +69,7 @@ export function CategoryManager({ onCategoryChange }: CategoryManagerProps) {
       setEditingCategory(null);
       setEditingName('');
       onCategoryChange?.();
-    } catch (err) {
+    } catch {
       // Error is handled by the hook
     } finally {
       setIsSubmitting(false);

--- a/src/components/image-library/ImageCard.tsx
+++ b/src/components/image-library/ImageCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState, useRef } from 'react';
+import Image from 'next/image';
 import { ImageMetadata, ImageCategory } from '@/types';
 
 interface ImageCardProps {
@@ -217,7 +218,7 @@ export const ImageCard: React.FC<ImageCardProps> = ({
       {/* Image Container */}
       <div
         className={`
-          aspect-square bg-gray-100 rounded-lg overflow-hidden cursor-pointer transition-all
+          relative aspect-square bg-gray-100 rounded-lg overflow-hidden cursor-pointer transition-all
           ${selected ? 'ring-2 ring-blue-500 ring-offset-2' : 'hover:shadow-md'}
           ${multiSelect ? '' : 'hover:scale-105'}
         `}
@@ -230,10 +231,11 @@ export const ImageCard: React.FC<ImageCardProps> = ({
                 <div className="animate-pulse bg-gray-200 w-full h-full"></div>
               </div>
             )}
-            <img
+            <Image
               src={image.url}
               alt={image.filename}
-              className={`w-full h-full object-cover transition-opacity ${
+              fill
+              className={`object-cover transition-opacity ${
                 imageLoaded ? 'opacity-100' : 'opacity-0'
               }`}
               onLoad={() => setImageLoaded(true)}

--- a/src/components/image-library/ImageDetailsModal.tsx
+++ b/src/components/image-library/ImageDetailsModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useState } from 'react';
+import Image from 'next/image';
 import { ImageMetadata, ImageCategory } from '@/types';
 
 interface ImageDetailsModalProps {
@@ -131,9 +132,11 @@ export const ImageDetailsModal: React.FC<ImageDetailsModalProps> = ({
           {/* Image Preview */}
           <div className="flex-1 bg-gray-50 flex items-center justify-center p-4">
             <div className="max-w-full max-h-full">
-              <img
+              <Image
                 src={image.url}
                 alt={image.filename}
+                width={image.dimensions.width}
+                height={image.dimensions.height}
                 className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
               />
             </div>

--- a/src/components/image-library/ImageUpload.tsx
+++ b/src/components/image-library/ImageUpload.tsx
@@ -63,7 +63,7 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
     });
   };
 
-  const uploadFile = async (file: File) => {
+  const uploadFile = useCallback(async (file: File) => {
     if (!user) {
       onUploadError('User not authenticated');
       return;
@@ -161,12 +161,12 @@ export const ImageUpload: React.FC<ImageUploadProps> = ({
         });
       }, 5000);
     }
-  };
+  }, [user, category, onUploadComplete, onUploadError]);
 
   const handleFiles = useCallback((files: FileList | File[]) => {
     const fileArray = Array.from(files);
     fileArray.forEach(uploadFile);
-  }, [category, user]);
+  }, [uploadFile]);
 
   const handleDragOver = useCallback((e: React.DragEvent) => {
     e.preventDefault();

--- a/src/hooks/useImages.ts
+++ b/src/hooks/useImages.ts
@@ -86,7 +86,7 @@ export const useImages = (): UseImagesReturn => {
       console.error('Error deleting image:', err);
       throw err; // Re-throw to allow component to handle
     }
-  }, [user]);
+  }, [user, refreshStorageUsage, refreshCategoryCount]);
 
   const renameImage = useCallback(async (imageId: string, newFilename: string) => {
     if (!user) return;
@@ -122,7 +122,7 @@ export const useImages = (): UseImagesReturn => {
       console.error('Error moving image:', err);
       throw err;
     }
-  }, [user]);
+  }, [user, refreshCategoryCount]);
 
   const refreshStorageUsage = useCallback(async () => {
     if (!user) {

--- a/src/lib/firestore.ts
+++ b/src/lib/firestore.ts
@@ -11,7 +11,6 @@ import {
   orderBy,
   limit,
   Timestamp,
-  DocumentReference,
   CollectionReference,
   QueryConstraint,
 } from 'firebase/firestore';

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -6,9 +6,7 @@ import {
   deleteObject,
   listAll,
   getMetadata,
-  UploadResult,
   StorageReference,
-  UploadTask,
 } from 'firebase/storage';
 import { storage } from './firebase';
 


### PR DESCRIPTION
## Summary
- Replace plain `<img>` tags with optimized `next/image` components in image library UI
- Stabilize image upload and management hooks by tightening `useCallback` dependencies
- Add unit tests for storage helpers and clean up unused imports/variables

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2e08d3b688330a7bcbb3c96a9ea68