### PR TITLE
refactor: fix lint errors

### DIFF
--- a/setup-cors.mjs
+++ b/setup-cors.mjs
@@ -1,7 +1,7 @@
 // Script to set up CORS for Firebase Storage
 // This needs to be run with proper Google Cloud SDK authentication
 
-const { Storage } = require('@google-cloud/storage');
+import { Storage } from '@google-cloud/storage';
 
 async function setupCORS() {
   const storage = new Storage({
@@ -29,3 +29,4 @@ async function setupCORS() {
 }
 
 setupCORS();
+

--- a/src/types/templates.ts
+++ b/src/types/templates.ts
@@ -29,7 +29,7 @@ export interface GenerationWizardStep {
   id: string;
   title: string;
   description: string;
-  component: React.ComponentType<any>;
+  component: React.ComponentType<unknown>;
 }
 
 export interface AssetGenerationRequest {


### PR DESCRIPTION
## Summary
- convert CORS setup script to ESM import to satisfy lint rules
- tighten GenerationWizardStep type to avoid `any`

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@testing-library/dom' and Firestore utilities expectations)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ed34dea8833098e71a04a3853b86